### PR TITLE
Add Respoke-SDK header to ws and http requests

### DIFF
--- a/RespokeSDK.xcodeproj/project.pbxproj
+++ b/RespokeSDK.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		D47DC5AB1B82A39F0022087C /* HangupTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D47DC5AA1B82A39F0022087C /* HangupTests.m */; };
 		D48B3A741B0E7B8C00F5C4CB /* libRespokeSDK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 18E942091993D46E00C8B142 /* libRespokeSDK.a */; };
 		FC72B8F11BB83B7D00548EDB /* NSString+urlencode.m in Sources */ = {isa = PBXBuildFile; fileRef = FC72B8F01BB83B7D00548EDB /* NSString+urlencode.m */; settings = {ASSET_TAGS = (); }; };
+		FCCB2D061BBA2FDF000BDC3F /* RespokeVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = FCCB2D051BBA2FDF000BDC3F /* RespokeVersion.m */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -205,6 +206,8 @@
 		D4A68E211B0FEA990018307F /* SocketIOTransportXHR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SocketIOTransportXHR.h; sourceTree = "<group>"; };
 		FC72B8EF1BB83B7D00548EDB /* NSString+urlencode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+urlencode.h"; sourceTree = "<group>"; };
 		FC72B8F01BB83B7D00548EDB /* NSString+urlencode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+urlencode.m"; sourceTree = "<group>"; };
+		FCCB2D051BBA2FDF000BDC3F /* RespokeVersion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RespokeVersion.m; sourceTree = "<group>"; };
+		FCCB2D071BBA2FFB000BDC3F /* RespokeVersion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RespokeVersion.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -379,6 +382,8 @@
 				18E9444D1993EBF800C8B142 /* RespokeGroup+private.h */,
 				18E942461993D61000C8B142 /* RespokeSignalingChannel.h */,
 				18E942471993D61000C8B142 /* RespokeSignalingChannel.m */,
+				FCCB2D071BBA2FFB000BDC3F /* RespokeVersion.h */,
+				FCCB2D051BBA2FDF000BDC3F /* RespokeVersion.m */,
 				18E942481993D61000C8B142 /* RestAPI */,
 				D4A68E1B1B0FEA990018307F /* Socket.IO */,
 				18E9420F1993D46E00C8B142 /* Supporting Files */,
@@ -668,6 +673,7 @@
 				18E942541993D61000C8B142 /* RespokeSignalingChannel.m in Sources */,
 				18E942521993D61000C8B142 /* RespokeEndpoint.m in Sources */,
 				18E942571993D61000C8B142 /* APITransaction.m in Sources */,
+				FCCB2D061BBA2FDF000BDC3F /* RespokeVersion.m in Sources */,
 				18E942531993D61000C8B142 /* RespokeGroup.m in Sources */,
 				D452EDB11A68A8EE0080D954 /* RespokeMediaStats.m in Sources */,
 				FC72B8F11BB83B7D00548EDB /* NSString+urlencode.m in Sources */,

--- a/RespokeSDK.xcodeproj/project.pbxproj
+++ b/RespokeSDK.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		D452EDB11A68A8EE0080D954 /* RespokeMediaStats.m in Sources */ = {isa = PBXBuildFile; fileRef = D452EDB01A68A8EE0080D954 /* RespokeMediaStats.m */; };
 		D47DC5AB1B82A39F0022087C /* HangupTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D47DC5AA1B82A39F0022087C /* HangupTests.m */; };
 		D48B3A741B0E7B8C00F5C4CB /* libRespokeSDK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 18E942091993D46E00C8B142 /* libRespokeSDK.a */; };
+		FC72B8F11BB83B7D00548EDB /* NSString+urlencode.m in Sources */ = {isa = PBXBuildFile; fileRef = FC72B8F01BB83B7D00548EDB /* NSString+urlencode.m */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -202,6 +203,8 @@
 		D4A68E1F1B0FEA990018307F /* SocketIOTransport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SocketIOTransport.h; sourceTree = "<group>"; };
 		D4A68E201B0FEA990018307F /* SocketIOTransportWebsocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SocketIOTransportWebsocket.h; sourceTree = "<group>"; };
 		D4A68E211B0FEA990018307F /* SocketIOTransportXHR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SocketIOTransportXHR.h; sourceTree = "<group>"; };
+		FC72B8EF1BB83B7D00548EDB /* NSString+urlencode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+urlencode.h"; sourceTree = "<group>"; };
+		FC72B8F01BB83B7D00548EDB /* NSString+urlencode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+urlencode.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -361,6 +364,8 @@
 				18E9423E1993D61000C8B142 /* RespokeCall.m */,
 				18E9444A1993EBF800C8B142 /* RespokeCall+private.h */,
 				D452EDB01A68A8EE0080D954 /* RespokeMediaStats.m */,
+				FC72B8EF1BB83B7D00548EDB /* NSString+urlencode.h */,
+				FC72B8F01BB83B7D00548EDB /* NSString+urlencode.m */,
 				D452EDB31A69C01D0080D954 /* RespokeMediaStats+private.h */,
 				18E942401993D61000C8B142 /* RespokeClient.m */,
 				18E9444B1993EBF800C8B142 /* RespokeClient+private.h */,
@@ -665,6 +670,7 @@
 				18E942571993D61000C8B142 /* APITransaction.m in Sources */,
 				18E942531993D61000C8B142 /* RespokeGroup.m in Sources */,
 				D452EDB11A68A8EE0080D954 /* RespokeMediaStats.m in Sources */,
+				FC72B8F11BB83B7D00548EDB /* NSString+urlencode.m in Sources */,
 				18E942501993D61000C8B142 /* RespokeCall.m in Sources */,
 				180BE48D19F9A8DF005BA3A1 /* RespokeDirectConnection.m in Sources */,
 			);

--- a/RespokeSDK/NSString+urlencode.h
+++ b/RespokeSDK/NSString+urlencode.h
@@ -1,0 +1,25 @@
+//
+//  NSString+urlencode.h
+//  Respoke SDK
+//
+//  Copyright 2015, Digium, Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under The MIT License found in the
+//  LICENSE file in the root directory of this source tree.
+//
+//  For all details and documentation:  https://www.respoke.io
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (NSString_Extended)
+
+/**
+ *  Url-encodes a string, suitable for placing into a url as a portion of the query string
+ *
+ * @return The url-encoded version of the string
+ */
+- (NSString *)urlencode;
+
+@end

--- a/RespokeSDK/NSString+urlencode.h
+++ b/RespokeSDK/NSString+urlencode.h
@@ -16,7 +16,8 @@
 @interface NSString (NSString_Extended)
 
 /**
- *  Url-encodes a string, suitable for placing into a url as a portion of the query string
+ *  Url-encodes a string, suitable for placing into a url as a portion of the query string. 
+ *  Source taken from http://stackoverflow.com/a/8088484/355743
  *
  * @return The url-encoded version of the string
  */

--- a/RespokeSDK/NSString+urlencode.m
+++ b/RespokeSDK/NSString+urlencode.m
@@ -1,0 +1,39 @@
+//
+//  NSString+urlencode.m
+//  Respoke SDK
+//
+//  Copyright 2015, Digium, Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under The MIT License found in the
+//  LICENSE file in the root directory of this source tree.
+//
+//  For all details and documentation:  https://www.respoke.io
+//
+
+#import "NSString+urlencode.h"
+
+@implementation NSString (NSString_Extended)
+
+- (NSString *)urlencode {
+    NSMutableString *output = [NSMutableString string];
+    const unsigned char *source = (const unsigned char *)[self UTF8String];
+    const unsigned long sourceLen = strlen((const char *)source);
+    for (int i = 0; i < sourceLen; ++i) {
+        const unsigned char thisChar = source[i];
+        if (thisChar == ' '){
+            [output appendString:@"+"];
+        } else if (thisChar == '.' || thisChar == '-' || thisChar == '_' || thisChar == '~' ||
+                   (thisChar >= 'a' && thisChar <= 'z') ||
+                   (thisChar >= 'A' && thisChar <= 'Z') ||
+                   (thisChar >= '0' && thisChar <= '9')) {
+            [output appendFormat:@"%c", thisChar];
+        } else {
+            [output appendFormat:@"%%%02X", thisChar];
+        }
+    }
+    return output;
+}
+
+@end
+

--- a/RespokeSDK/RespokeSignalingChannel.m
+++ b/RespokeSDK/RespokeSignalingChannel.m
@@ -15,7 +15,8 @@
 #import "RespokeCall+private.h"
 #import "RespokeEndpoint+private.h"
 #import "RespokeClient+private.h"
-
+#import "NSString+urlencode.h"
+#import "APITransaction.h"
 
 #define RESPOKE_SOCKETIO_PORT 443
 
@@ -54,8 +55,8 @@
 {
     socketIO = [[SocketIO alloc] initWithDelegate:self];
     socketIO.useSecure = useHTTPS;
-    
-    [socketIO connectToHost:baseURL onPort:RESPOKE_SOCKETIO_PORT withParams:[NSDictionary dictionaryWithObjectsAndKeys:appToken, @"app-token", @"0.10.0", @"__sails_io_sdk_version", nil]];
+    NSString *sdkHeader = [APITransaction getSDKHeader];
+    [socketIO connectToHost:baseURL onPort:RESPOKE_SOCKETIO_PORT withParams:[NSDictionary dictionaryWithObjectsAndKeys:appToken, @"app-token", @"0.10.0", @"__sails_io_sdk_version", [sdkHeader urlencode], @"Respoke-SDK", nil]];
 }
 
 
@@ -63,8 +64,9 @@
 {
     if (self.connected)
     {
+        NSString *sdkHeader = [APITransaction getSDKHeader];
         NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-        [dict setObject:@{@"App-Token": appToken} forKey:@"headers"];
+        [dict setObject:@{@"App-Token": appToken, @"Respoke-SDK": sdkHeader} forKey:@"headers"];
         [dict setObject:url forKey:@"url"];
 
         NSUInteger dataLen = 0;

--- a/RespokeSDK/RespokeVersion.h
+++ b/RespokeSDK/RespokeVersion.h
@@ -1,0 +1,19 @@
+//
+//  RespokeVersion.h
+//  Respoke SDK
+//
+//  Copyright 2015, Digium, Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under The MIT License found in the
+//  LICENSE file in the root directory of this source tree.
+//
+//  For all details and documentation:  https://www.respoke.io
+//
+
+#ifndef RespokeVersion_h
+#define RespokeVersion_h
+
+const NSString *getSDKVersion(void);
+
+#endif /* RespokeVersion_h */

--- a/RespokeSDK/RespokeVersion.m
+++ b/RespokeSDK/RespokeVersion.m
@@ -1,0 +1,21 @@
+//
+//  RespokeVersion.h
+//  Respoke SDK
+//
+//  Copyright 2015, Digium, Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under The MIT License found in the
+//  LICENSE file in the root directory of this source tree.
+//
+//  For all details and documentation:  https://www.respoke.io
+//
+
+#import "RespokeVersion.h"
+
+static NSString* const sdk_version = @"1.1.1";
+
+const NSString *getSDKVersion(void)
+{
+    return sdk_version;
+}

--- a/RespokeSDK/RestAPI/APITransaction.h
+++ b/RespokeSDK/RestAPI/APITransaction.h
@@ -73,6 +73,16 @@
 
 
 /**
+ *  Retrieve the SDK header sent with HTTP and WS requests. Includes
+ *  the version of the SDK and the iOS version in the format
+ *  "Respoke-iOS/<sdk_version> (<os name> <os version>)"
+ *
+ *  @return The SDK header
+ */
++ (NSString*)getSDKHeader;
+
+
+/**
  *  Initialize the transaction class and specify the base URL of the Respoke service
  *
  *  @param newBaseURL The base URL of the Respoke service

--- a/RespokeSDK/RestAPI/APITransaction.m
+++ b/RespokeSDK/RestAPI/APITransaction.m
@@ -13,6 +13,7 @@
 
 #import <UIKit/UIKit.h>
 #import "APITransaction.h"
+#import "RespokeVersion.h"
 
 #define HTTP_TIMEOUT 10.0f
 
@@ -21,9 +22,10 @@
 
 + (NSString*)getSDKHeader
 {
-    NSString *osName = [UIDevice currentDevice].systemName;
-    NSString *osVersion = [UIDevice currentDevice].systemVersion;
-    return [NSString stringWithFormat:@"Respoke-iOS (%@ %@)", osName, osVersion];
+    const NSString *osName = [UIDevice currentDevice].systemName;
+    const NSString *osVersion = [UIDevice currentDevice].systemVersion;
+    const NSString *sdkVersion = getSDKVersion();
+    return [NSString stringWithFormat:@"Respoke-iOS/%@ (%@ %@)", sdkVersion, osName, osVersion];
 }
 
 - (instancetype)initWithBaseUrl:(NSString*)newBaseURL

--- a/RespokeSDK/RestAPI/APITransaction.m
+++ b/RespokeSDK/RestAPI/APITransaction.m
@@ -11,6 +11,7 @@
 //  For all details and documentation:  https://www.respoke.io
 //
 
+#import <UIKit/UIKit.h>
 #import "APITransaction.h"
 
 #define HTTP_TIMEOUT 10.0f
@@ -18,6 +19,12 @@
 
 @implementation APITransaction
 
++ (NSString*)getSDKHeader
+{
+    NSString *osName = [UIDevice currentDevice].systemName;
+    NSString *osVersion = [UIDevice currentDevice].systemVersion;
+    return [NSString stringWithFormat:@"Respoke-iOS (%@ %@)", osName, osVersion];
+}
 
 - (instancetype)initWithBaseUrl:(NSString*)newBaseURL
 {
@@ -56,11 +63,13 @@
     }
     else
     {
+        NSString *sdkHeader = [APITransaction getSDKHeader];
         NSURL *theURL = [NSURL URLWithString:self.baseURL];
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:theURL cachePolicy:NSURLRequestReloadIgnoringLocalAndRemoteCacheData timeoutInterval:HTTP_TIMEOUT];
         [request setHTTPMethod:httpMethod];
         [request setValue:@"application/xml" forHTTPHeaderField:@"Accept"];
         [request setValue:contentType forHTTPHeaderField:@"Content-Type"];
+        [request setValue:sdkHeader forHTTPHeaderField:@"Respoke-SDK"];
         [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)[data length]] forHTTPHeaderField:@"Content-length"];
         [request setHTTPBody:data];
         connection = [NSURLConnection connectionWithRequest:request delegate:self];


### PR DESCRIPTION
This patch adds the "Respoke-SDK" header to websocket connect, requests, and HTTP[S] requests. This will help the Respoke team understand SDK usage information. It contains the name of the SDK
and the os name and version.

I wasn't able to pull the SDK version at this time, because I don't think there's any way to pull the version out of the cocoapods .podspec file, since it is essentially ruby source. I am thinking we'll need to pull the version out into a separate file, and read that file in the .podspec as well as our source. I'm not sure the best solution to that, though, so I would appreciate any suggestions.

<img width="547" alt="screen shot 2015-09-27 at 12 37 59 pm" src="https://cloud.githubusercontent.com/assets/309219/10124198/e53815a8-6514-11e5-8887-993d3b1615a0.png">
<img width="1001" alt="screen shot 2015-09-27 at 11 59 29 am" src="https://cloud.githubusercontent.com/assets/309219/10124197/e537d5b6-6514-11e5-9923-565a33938093.png">
<img width="606" alt="screen shot 2015-09-27 at 11 59 54 am" src="https://cloud.githubusercontent.com/assets/309219/10124199/e538b1c0-6514-11e5-8297-3963cef46825.png">

Related to MER-4340

P.S. I tested this in the Simulator and most all the tests passed, except the ones that require WebRTC which isn't available in the Simulator.

<img width="253" alt="screen shot 2015-09-27 at 12 05 23 pm" src="https://cloud.githubusercontent.com/assets/309219/10124200/e5395698-6514-11e5-9dea-c601cd9c3b7e.png">
